### PR TITLE
Added stats to ApexUser struct, created a test and added a workflow

### DIFF
--- a/.github/workflows/crates_io.yml
+++ b/.github/workflows/crates_io.yml
@@ -1,0 +1,29 @@
+name: Publish on Crates.io
+
+on:
+  push:
+    tags:
+      - '*'
+  
+  workflow_run:
+    workflows: [Rust]
+    types: [completed]
+      
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps: 
+      - name: Checkout
+        uses: actions/checkout@v2
+        
+      - name: Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          
+      - name: Publish crate
+        uses: katyo/publish-crates@v1
+        with:
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          ignore-unpublished-changes: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,29 @@
+name: Rust
+
+on:
+  push:
+    branches: [ main ]
+    tags:
+      - '*'
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install latest stable
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt 
+
+      - name: Check code format
+        run: cargo fmt --all -- --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -96,6 +96,3 @@ jobs:
         
       - name: Cargo test release
         run: cargo test --release --all-features --verbose
-          
-          
-            

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,11 +2,11 @@ name: Rust
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
     tags:
       - '*'
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,3 +27,75 @@ jobs:
 
       - name: Check code format
         run: cargo fmt --all -- --check
+
+  stable-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        
+      - name: Install latest stable
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+          
+      - name: Build debug
+        run: cargo build --verbose
+        
+      - name: Build release
+        run: cargo build --release --verbose
+        
+      - uses: actions/cache@v2
+        id: stable-cargo-build
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-stable-cargo-${{ hashFiles('**/Cargo.lock') }}
+          
+  stable-tests:
+    runs-on: ubuntu-latest
+    needs: ['stable-build']
+    steps:
+      - name: Restore cache
+        uses: actions/cache@v2
+        id: stable-cargo-build
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-stable-cargo-${{ hashFiles('**/Cargo.lock') }}
+          
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        
+      - name: Install latest stable
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+          
+      - name: Create envfile
+        run: |
+          touch .env
+          echo API_KEY=${{ secrets.API_KEY }} >> .env
+          echo USERNAME=${{ secrets.APEX_USERNAME }} >> .env
+          cat .env
+
+      - name: Cargo test debug
+        run: cargo test --all-features --verbose
+        
+      - name: Cargo test release
+        run: cargo test --release --all-features --verbose
+          
+          
+            

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /src/main.rs
+.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ version = 3
 name = "apex_legends"
 version = "0.1.2"
 dependencies = [
+ "dotenv",
  "reqwest",
  "serde",
  "serde_json",
@@ -69,6 +70,12 @@ name = "core-foundation-sys"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+
+[[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "encoding_rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "apex_legends"
-version = "0.1.3"
+version = "0.1.2"
 dependencies = [
  "dotenv",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,8 +3,8 @@
 version = 3
 
 [[package]]
-name = "apex_legends"
-version = "0.1.2"
+name = "apex_legends_api"
+version = "0.1.4"
 dependencies = [
  "dotenv",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "apex_legends"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "dotenv",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,16 @@
 [package]
-name = "apex_legends"
+name = "apex_legends_api"
 description = "An API wrapper for the MozambiqueHe.re Apex Legends API."
-version = "0.1.2"
+version = "0.1.4"
 edition = "2018"
-author = "KasprDev <kasprdev@gmail.com>"
-repository = "https://github.com/KasprDev/Apex-Legends-API-Rust"
+authors = ["KasprDev <kasprdev@gmail.com>", "margual56 <marcos56@mailbox.org>"]
+repository = "https://github.com/margual56/Apex-Legends-API-Rust"
 keywords = ["apex_legends", "apex", "game", "video_game", "api"]
 categories = ["api-bindings", "asynchronous"]
-exclude = ["src/main.rs"]
-license = "MIT OR Apache-2.0"
+exclude = ["src/main.rs", ".github/"]
+license = "MIT"
+readme = "README.md"
+
 
 [dependencies]
 tokio = { version = "1.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "apex_legends"
 description = "An API wrapper for the MozambiqueHe.re Apex Legends API."
-version = "0.1.3"
+version = "0.1.2"
 edition = "2018"
 author = "KasprDev <kasprdev@gmail.com>"
 repository = "https://github.com/KasprDev/Apex-Legends-API-Rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ tokio = { version = "1.0", features = ["full"] }
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0"
+dotenv = "0.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,6 @@ tokio = { version = "1.0", features = ["full"] }
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0"
+
+[dev-dependencies]
 dotenv = "0.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "apex_legends"
 description = "An API wrapper for the MozambiqueHe.re Apex Legends API."
-version = "0.1.2"
+version = "0.1.3"
 edition = "2018"
 author = "KasprDev <kasprdev@gmail.com>"
 repository = "https://github.com/KasprDev/Apex-Legends-API-Rust"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Marcos Gutiérrez Alonso
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Rust](https://github.com/margual56/Apex-Legends-API-Rust/actions/workflows/rust.yml/badge.svg?branch=master)](https://github.com/margual56/Apex-Legends-API-Rust/actions/workflows/rust.yml)
+
 # Apex Legends API (in Rust)
 
 This package utilizes the Apex Legends Status (https://apexlegendsstatus.com) API.

--- a/README.md
+++ b/README.md
@@ -9,13 +9,20 @@ use apex_legends;
 
 #[tokio::main]
 async fn main() {
-    match apex_legends::get_user("HeyImLifeline".to_string(), "your_api_key").await {
+    match apex_legends::get_user_retry("HeyImLifeline".to_string(), "your_api_key", true).await {
         Ok(data) => println!("You are level {}.", data.global.level),
-        Err(e) => {
-            println!("there was an error!: {}", e)
-        }
+        Err(e) => println!("There was an error!: {}", e)
     }
 }
 ```
 
 I have no affiliation with Apex Legends, EA, or Apex Legends Status.
+
+## A note about the failing test
+
+This is a known issue in the API. It has a rate limit, so it should return code 429 when the limit is reached. Instead, it returns 200 OK, so the library immediately retries and, unsurprisingly, it fails.
+
+
+# Authors
+
+The original author is [KasprDev](https://github.com/KasprDev), and this is a fork with some improvements for stability and extra features. Some of them were upstreamed, but not all of them as of yet.

--- a/src/data_types.rs
+++ b/src/data_types.rs
@@ -185,8 +185,8 @@ pub struct ApexMapRotationItem {
 
 #[derive(Deserialize, Debug)]
 pub struct Stat<V> {
-    name: String,
-    value: V,
+    pub name: String,
+    pub value: V,
 }
 
 #[derive(Deserialize, Debug)]

--- a/src/data_types.rs
+++ b/src/data_types.rs
@@ -14,6 +14,8 @@ pub struct ApexGlobal {
     pub avatar: String,
     pub platform: String,
     pub level: i32,
+    #[serde(alias = "levelPrestige")]
+    pub level_prestige: i32,
     #[serde(alias = "toNextLevelPercent")]
     pub to_next_level_percent: i32,
     pub rank: ApexRank,

--- a/src/data_types.rs
+++ b/src/data_types.rs
@@ -199,3 +199,9 @@ pub struct ApexStats {
     pub games_played: Stat<i32>,
     pub kd: Stat<String>,
 }
+
+#[derive(Deserialize, Debug)]
+pub struct ApexError {
+    #[serde(alias = "Error")]
+    pub message: String,
+}

--- a/src/data_types.rs
+++ b/src/data_types.rs
@@ -1,4 +1,4 @@
-use serde::{ Deserialize };
+use serde::Deserialize;
 
 #[derive(Deserialize)]
 pub struct ApexUser {
@@ -37,13 +37,13 @@ pub struct ApexRealtime {
     #[serde(alias = "selectedLegend")]
     pub selected_legend: String,
     #[serde(alias = "currentState")]
-    pub current_state: String
+    pub current_state: String,
 }
 
 #[derive(Deserialize)]
 pub struct ApexBattlepass {
     pub level: String,
-    pub history: ApexBattlepassHistory
+    pub history: ApexBattlepassHistory,
 }
 
 #[derive(Deserialize)]
@@ -57,7 +57,7 @@ pub struct ApexBattlepassHistory {
     pub season7: i32,
     pub season8: i32,
     pub season9: i32,
-    pub season10: i32
+    pub season10: i32,
 }
 
 #[derive(Deserialize)]
@@ -71,7 +71,7 @@ pub struct ApexRank {
     #[serde(alias = "rankImg")]
     pub rank_img: String,
     #[serde(alias = "rankedSeason")]
-    pub ranked_season: String
+    pub ranked_season: String,
 }
 
 #[derive(Deserialize)]
@@ -81,7 +81,7 @@ pub struct ApexBans {
     #[serde(alias = "remainingSeconds")]
     pub remaining_seconds: i32,
     #[serde(alias = "last_banReason")]
-    pub last_ban_reason: String
+    pub last_ban_reason: String,
 }
 
 #[derive(Deserialize, Debug)]
@@ -108,7 +108,7 @@ pub struct ApexGame {
     pub arenas_score_change: i32,
     #[serde(alias = "ArenasScore")]
     pub arenas_score: i32,
-    pub cosmetics: ApexCosmetics
+    pub cosmetics: ApexCosmetics,
 }
 
 #[derive(Deserialize, Debug)]
@@ -124,15 +124,14 @@ pub struct ApexCosmetics {
     #[serde(alias = "frameRarity")]
     pub frame_rarity: String,
     #[serde(alias = "introRarity")]
-    pub intro_rarity: String
-    
+    pub intro_rarity: String,
 }
 
 #[derive(Deserialize, Debug)]
 pub struct ApexGameData {
     pub key: String,
     pub value: i32,
-    pub name: Option<String>
+    pub name: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -140,7 +139,7 @@ pub struct ApexProfile {
     pub name: String,
     pub uid: String,
     pub pid: String,
-    pub avatar: String
+    pub avatar: String,
 }
 
 #[derive(Deserialize, Debug)]
@@ -149,7 +148,7 @@ pub struct ApexMapRotation {
     pub arenas: ApexMapRotationData,
     pub ranked: ApexRankedMapRotationData,
     #[serde(alias = "arenasRanked")]
-    pub arenas_ranked: ApexMapRotationData
+    pub arenas_ranked: ApexMapRotationData,
 }
 
 #[derive(Deserialize, Debug)]
@@ -163,7 +162,6 @@ pub struct ApexRankedMapRotationData {
     pub current: ApexRankedMapRotationItem,
     pub next: ApexRankedMapRotationItem,
 }
-
 
 #[derive(Deserialize, Debug)]
 pub struct ApexRankedMapRotationItem {
@@ -182,7 +180,7 @@ pub struct ApexMapRotationItem {
     #[serde(alias = "DurationInSecs")]
     pub duration_in_seconds: i32,
     #[serde(alias = "DurationInMinutes")]
-    pub duration_in_minutes: i32
+    pub duration_in_minutes: i32,
 }
 
 #[derive(Deserialize, Debug)]

--- a/src/data_types.rs
+++ b/src/data_types.rs
@@ -3,9 +3,10 @@ use serde::{ Deserialize };
 #[derive(Deserialize)]
 pub struct ApexUser {
     pub global: ApexGlobal,
-    pub realtime: ApexRealtime
+    pub realtime: ApexRealtime,
+    #[serde(alias = "total")]
+    pub stats: ApexStats,
 }
-
 #[derive(Deserialize)]
 pub struct ApexGlobal {
     pub name: String,
@@ -182,4 +183,21 @@ pub struct ApexMapRotationItem {
     pub duration_in_seconds: i32,
     #[serde(alias = "DurationInMinutes")]
     pub duration_in_minutes: i32
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Stat<V> {
+    name: String,
+    value: V,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ApexStats {
+    #[serde(alias = "kills")]
+    pub br_kills: Stat<i32>,
+    #[serde(alias = "damage")]
+    pub br_damage: Stat<i32>,
+    pub arenas_damage: Stat<i32>,
+    pub games_played: Stat<i32>,
+    pub kd: Stat<String>,
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -19,6 +19,7 @@ pub async fn get_request(url: String) -> Result<String, (reqwest::Error, Option<
     }
 }
 
+#[allow(dead_code)]
 pub async fn post_request(url: &str, body: String) -> Result<String, reqwest::Error> {
     let client = reqwest::Client::new();
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,9 +1,21 @@
-use reqwest;
+use reqwest::{self, header::HeaderMap};
 
-pub async fn get_request(url: String) -> Result<String, reqwest::Error> {
-    match reqwest::get(url).await?.text().await {
-        Ok(data) => Ok(data),
-        Err(e) => Err(e),
+pub async fn get_request(url: String) -> Result<String, (reqwest::Error, Option<HeaderMap>)> {
+    let response = reqwest::get(url).await;
+
+    match response {
+        Ok(res) => {
+            let headers = res.headers().clone();
+
+            match res.error_for_status() {
+                Ok(r) => Ok(r
+                    .text()
+                    .await
+                    .expect("Could not retrieve text from the successful request")),
+                Err(e) => Err((e, Some(headers))), //Err((, Some(headers))),
+            }
+        }
+        Err(e) => Err((e, None)),
     }
 }
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -3,7 +3,7 @@ use reqwest;
 pub async fn get_request(url: String) -> Result<String, reqwest::Error> {
     match reqwest::get(url).await?.text().await {
         Ok(data) => Ok(data),
-        Err(e) => Err(e)
+        Err(e) => Err(e),
     }
 }
 
@@ -12,6 +12,6 @@ pub async fn post_request(url: &str, body: String) -> Result<String, reqwest::Er
 
     match client.post(url).body(body).send().await?.text().await {
         Ok(data) => Ok(data),
-        Err(e) => Err(e)
+        Err(e) => Err(e),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,12 +45,12 @@ fn get_rate(header: Option<HeaderMap>) -> f32 {
 
 /// Gets information about a User. This version automatically retries if the API returns code 429 (too many requests).
 /// For the sleep time it reads the `x-current-rate` header or uses the DEFAULT_RATE
-/// See https://apexlegendsapi.com/#player-statistics
+/// See [https://apexlegendsapi.com/#player-statistics](https://apexlegendsapi.com/#player-statistics)
 ///
 /// # Arguments
 ///
 /// * `username` - The Origin username of the player
-/// * `api_key` - The API key for https://apexlegendsstatus.com
+/// * `api_key` - The API key for [https://apexlegendsstatus.com](https://apexlegendsstatus.com)
 /// * `retry` - Wether to retry after a timeout or error out immediately
 ///
 /// # Examples
@@ -112,12 +112,12 @@ pub async fn get_user_retry(
 }
 
 /// Gets information about a User. This version does not handle code 429 (too many requests)
-/// See https://apexlegendsapi.com/#player-statistics
+/// See [https://apexlegendsapi.com/#player-statistics](https://apexlegendsapi.com/#player-statistics)
 ///
 /// # Arguments
 ///
 /// * `username` - The Origin username of the player
-/// * `api_key` - The API key for https://apexlegendsstatus.com
+/// * `api_key` - The API key for [https://apexlegendsstatus.com](https://apexlegendsstatus.com)
 ///
 /// # Examples
 /// ```
@@ -167,10 +167,10 @@ pub async fn get_user(username: String, api_key: &str) -> Result<data_types::Ape
 
 /// Gets information about the recent games.
 /// You must be whitelisted to use this API. It has a strict limit of 5 uniques players queried per hour.
-/// See https://apexlegendsapi.com/#match-history
+/// See [https://apexlegendsapi.com/#match-history](https://apexlegendsapi.com/#match-history)
 ///
 /// * `user_id` - The player's UID
-/// * `api_key` - The API key for https://apexlegendsstatus.com
+/// * `api_key` - The API key for [https://apexlegendsstatus.com](https://apexlegendsstatus.com)
 pub async fn get_recent_games(
     user_id: String,
     api_key: &str,
@@ -196,7 +196,7 @@ pub async fn get_recent_games(
 }
 
 /// Returns a player's UID from a given name, but also works with Playstation and Xbox players
-/// See https://apexlegendsapi.com/#name-to-uid
+/// See [https://apexlegendsapi.com/#name-to-uid](https://apexlegendsapi.com/#name-to-uid)
 ///
 /// ## Warning
 /// This function does not work as intended:
@@ -205,7 +205,7 @@ pub async fn get_recent_games(
 ///
 /// # Parameters
 /// * `user_id` - The player's UID
-/// * `api_key` - The API key for https://apexlegendsstatus.com
+/// * `api_key` - The API key for [https://apexlegendsstatus.com](https://apexlegendsstatus.com)
 /// * `retry` - Wether to retry after a timeout or error out immediately
 pub async fn get_uid_from_username_retry(
     username: String,
@@ -241,6 +241,12 @@ pub async fn get_uid_from_username_retry(
     }
 }
 
+/// Returns a player's UID from a given name, but also works with Playstation and Xbox players
+/// See [https://apexlegendsapi.com/#name-to-uid](https://apexlegendsapi.com/#name-to-uid)
+///
+/// # Parameters
+/// * `user_id` - The player's UID
+/// * `api_key` - The API key for [https://apexlegendsstatus.com](https://apexlegendsstatus.com)
 pub async fn get_uid_from_username(
     username: String,
     api_key: &str,
@@ -268,6 +274,13 @@ pub async fn get_uid_from_username(
     }
 }
 
+/// The map rotation API will return the current and next map for Battle Royale and Arenas, for both pubs and ranked modes.
+/// Control map rotation is also available.
+/// See [https://apexlegendsapi.com/#map-rotation](https://apexlegendsapi.com/#map-rotation)
+///
+/// # Parameters
+/// * `api_key` - The API key for [https://apexlegendsstatus.com](https://apexlegendsstatus.com)
+/// * `retry` - Wether to retry after a timeout or error out immediately
 pub async fn get_map_rotation_retry(
     api_key: &str,
     retry: bool,
@@ -298,6 +311,12 @@ pub async fn get_map_rotation_retry(
     }
 }
 
+/// The map rotation API will return the current and next map for Battle Royale and Arenas, for both pubs and ranked modes.
+/// Control map rotation is also available.
+/// See [https://apexlegendsapi.com/#map-rotation](https://apexlegendsapi.com/#map-rotation)
+///
+/// # Parameters
+/// * `api_key` - The API key for [https://apexlegendsstatus.com](https://apexlegendsstatus.com)
 pub async fn get_map_rotation(api_key: &str) -> Result<data_types::ApexMapRotation, String> {
     match http::get_request(format!(
         "https://api.mozambiquehe.re/maprotation?version=2&auth={}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,17 +55,27 @@ fn get_rate(header: Option<HeaderMap>) -> f32 {
 ///
 /// # Examples
 /// ```
-/// // This example automatically handles the 429 error code (too many requests)
-/// match apex_legends::get_user_retry(String::from(&user_name), &api_key, true).await {
-///    Ok(data) => {
-///        println!(
-///            "You are level {}, and you have {} kills.",
-///            data.global.level, data.stats.br_kills.value
-///        );
-///    }
-///    Err(e) => {
-///        println!("there was an error!: {}", e);
-///    }
+/// use std::env;
+///
+/// #[tokio::test]
+/// async fn user() {
+///     dotenv::dotenv().expect("Could not load .env file");
+///
+///     let user_name = env::var("USERNAME").expect("Expected key USERNAME");
+///     let api_key = env::var("API_KEY").expect("Expected key API_KEY");
+///
+///     // This example automatically handles the 429 error code (too many requests)
+///     match apex_legends::get_user_retry(String::from(&user_name), &api_key, true).await {
+///        Ok(data) => {
+///            println!(
+///                "You are level {}, and you have {} kills.",
+///                data.global.level, data.stats.br_kills.value
+///            );
+///        }
+///        Err(e) => {
+///            println!("there was an error!: {}", e);
+///        }
+///     }
 /// }
 /// ```
 pub async fn get_user_retry(
@@ -111,17 +121,27 @@ pub async fn get_user_retry(
 ///
 /// # Examples
 /// ```
-/// // This example will fail if the API returns the 429 error code (too many requests)
-/// match apex_legends::get_user(String::from(&user_name), &api_key).await {
-///    Ok(data) => {
-///        println!(
-///            "You are level {}, and you have {} kills.",
-///            data.global.level, data.stats.br_kills.value
-///        );
-///    }
-///    Err(e) => {
-///        println!("there was an error!: {}", e);
-///    }
+/// use std::env;
+///
+/// #[tokio::test]
+/// async fn user() {
+///     dotenv::dotenv().expect("Could not load .env file");
+///
+///     let user_name = env::var("USERNAME").expect("Expected key USERNAME");
+///     let api_key = env::var("API_KEY").expect("Expected key API_KEY");
+///
+///     // This example will fail if the API returns the 429 error code (too many requests)
+///     match apex_legends::get_user(String::from(&user_name), &api_key).await {
+///        Ok(data) => {
+///            println!(
+///                "You are level {}, and you have {} kills.",
+///                data.global.level, data.stats.br_kills.value
+///            );
+///        }
+///        Err(e) => {
+///            println!("there was an error!: {}", e);
+///        }
+///     }
 /// }
 /// ```
 pub async fn get_user(username: String, api_key: &str) -> Result<data_types::ApexUser, String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,50 +1,68 @@
-mod http;
 mod data_types;
+mod http;
 
 pub async fn get_user(username: String, api_key: &str) -> Result<data_types::ApexUser, String> {
-    match http::get_request(format!("https://api.mozambiquehe.re/bridge?version=5&platform=PC&player={}&auth={}", username, api_key)).await {
-        Ok(resp) => {
-            match serde_json::from_str(&resp) {
-                Ok(data) => Ok(data),
-                Err(e) => Err(format!("{}", e))
-            }
+    match http::get_request(format!(
+        "https://api.mozambiquehe.re/bridge?version=5&platform=PC&player={}&auth={}",
+        username, api_key
+    ))
+    .await
+    {
+        Ok(resp) => match serde_json::from_str(&resp) {
+            Ok(data) => Ok(data),
+            Err(e) => Err(format!("{}", e)),
         },
-        Err(_) => Err("There was an error getting your profile.".to_string())
+        Err(_) => Err("There was an error getting your profile.".to_string()),
     }
 }
 
-pub async fn get_recent_games(user_id: String, api_key: &str) -> Result<Vec<data_types::ApexGame>, String> {
-    match http::get_request(format!("https://api.mozambiquehe.re/games?auth={}&uid={}", api_key, user_id)).await {
-        Ok(resp) => {
-            match serde_json::from_str(&resp) {
-                Ok(data) => Ok(data),
-                Err(e) => Err(format!("{}", e))
-            }
+pub async fn get_recent_games(
+    user_id: String,
+    api_key: &str,
+) -> Result<Vec<data_types::ApexGame>, String> {
+    match http::get_request(format!(
+        "https://api.mozambiquehe.re/games?auth={}&uid={}",
+        api_key, user_id
+    ))
+    .await
+    {
+        Ok(resp) => match serde_json::from_str(&resp) {
+            Ok(data) => Ok(data),
+            Err(e) => Err(format!("{}", e)),
         },
-        Err(_) => Err("There was an error getting your recent matches.".to_string())
+        Err(_) => Err("There was an error getting your recent matches.".to_string()),
     }
 }
 
-pub async fn get_uid_from_username(username: String, api_key: &str) -> Result<data_types::ApexProfile, String> {
-    match http::get_request(format!("https://api.mozambiquehe.re/nametouid?player={}&platform=PC&auth={}", username, api_key)).await {
-        Ok(resp) => {
-            match serde_json::from_str(&resp) {
-                Ok(data) => Ok(data),
-                Err(e) => Err(format!("{}", e))
-            }
+pub async fn get_uid_from_username(
+    username: String,
+    api_key: &str,
+) -> Result<data_types::ApexProfile, String> {
+    match http::get_request(format!(
+        "https://api.mozambiquehe.re/nametouid?player={}&platform=PC&auth={}",
+        username, api_key
+    ))
+    .await
+    {
+        Ok(resp) => match serde_json::from_str(&resp) {
+            Ok(data) => Ok(data),
+            Err(e) => Err(format!("{}", e)),
         },
-        Err(_) => Err("There was an error getting the user id.".to_string())
+        Err(_) => Err("There was an error getting the user id.".to_string()),
     }
 }
 
 pub async fn get_map_rotation(api_key: &str) -> Result<data_types::ApexMapRotation, String> {
-    match http::get_request(format!("https://api.mozambiquehe.re/maprotation?version=2&auth={}", api_key)).await {
-        Ok(resp) => {
-            match serde_json::from_str(&resp) {
-                Ok(data) => Ok(data),
-                Err(_) => Err("Unable to deserialize JSON.".to_string())
-            }
+    match http::get_request(format!(
+        "https://api.mozambiquehe.re/maprotation?version=2&auth={}",
+        api_key
+    ))
+    .await
+    {
+        Ok(resp) => match serde_json::from_str(&resp) {
+            Ok(data) => Ok(data),
+            Err(_) => Err("Unable to deserialize JSON.".to_string()),
         },
-        Err(_) => Err("There was an error getting the map rotation.".to_string())
+        Err(_) => Err("There was an error getting the map rotation.".to_string()),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,129 @@
-mod data_types;
+use std::time::Duration;
+
+use reqwest::{header::HeaderMap, StatusCode};
+
+pub mod data_types;
 mod http;
 
+/// Default time to wait after a 429 error code
+pub const DEFAULT_RATE: f32 = 3.0;
+
+/// Simple function to standarize error messages given a Status Code
+fn handle_error<T>(status: StatusCode) -> Result<T, String> {
+    // Documentation: https://apexlegendsapi.com/#errors
+    match status {
+        StatusCode::TOO_MANY_REQUESTS => Err(String::from(
+            "Too many requests: wait 1 or 2 seconds please",
+        )),
+        StatusCode::UNAUTHORIZED => Err(String::from(
+            "The API key is incorrect, please contact the bot administrator",
+        )),
+        StatusCode::NOT_FOUND => Err(String::from("Either the apexlegendsapi.com")),
+        StatusCode::INTERNAL_SERVER_ERROR => {
+            Err(String::from("There was an internal server error"))
+        }
+        _ => Err(format!("{}", status)),
+    }
+}
+
+/// Given an optional header, return the value of the header if it exists or DEFAULT_RATE
+/// The header is `x-current-rate`
+fn get_rate(header: Option<HeaderMap>) -> f32 {
+    if let Some(h) = header {
+        if let Some(value) = h.get("x-current-rate") {
+            let default = DEFAULT_RATE.to_string();
+            let string_value = value.to_str().unwrap_or(default.as_str());
+
+            return string_value.parse().unwrap_or(DEFAULT_RATE);
+        } else {
+            return DEFAULT_RATE;
+        }
+    } else {
+        return DEFAULT_RATE;
+    }
+}
+
+/// Gets information about a User. This version automatically retries if the API returns code 429 (too many requests).
+/// For the sleep time it reads the `x-current-rate` header or uses the DEFAULT_RATE
+/// See https://apexlegendsapi.com/#player-statistics
+///
+/// # Arguments
+///
+/// * `username` - The Origin username of the player
+/// * `api_key` - The API key for https://apexlegendsstatus.com
+/// * `retry` - Wether to retry after a timeout or error out immediately
+///
+/// # Examples
+/// ```
+/// // This example automatically handles the 429 error code (too many requests)
+/// match apex_legends::get_user_retry(String::from(&user_name), &api_key, true).await {
+///    Ok(data) => {
+///        println!(
+///            "You are level {}, and you have {} kills.",
+///            data.global.level, data.stats.br_kills.value
+///        );
+///    }
+///    Err(e) => {
+///        println!("there was an error!: {}", e);
+///    }
+/// }
+/// ```
+pub async fn get_user_retry(
+    username: String,
+    api_key: &str,
+    retry: bool,
+) -> Result<data_types::ApexUser, String> {
+    match http::get_request(format!(
+        "https://api.mozambiquehe.re/bridge?version=5&platform=PC&player={}&auth={}",
+        username, api_key
+    ))
+    .await
+    {
+        Ok(resp) => match serde_json::from_str(&resp) {
+            Ok(data) => Ok(data),
+            Err(e) => Err(format!("{}", e)),
+        },
+        Err(e) => {
+            if let Some(code) = e.0.status() {
+                if code == StatusCode::TOO_MANY_REQUESTS && retry {
+                    let time = get_rate(e.1);
+
+                    tokio::time::sleep(Duration::from_secs_f32(time)).await;
+
+                    get_user(username, api_key).await
+                } else {
+                    handle_error::<data_types::ApexUser>(code)
+                }
+            } else {
+                Err(format!("{}", e.0))
+            }
+        }
+    }
+}
+
+/// Gets information about a User. This version does not handle code 429 (too many requests)
+/// See https://apexlegendsapi.com/#player-statistics
+///
+/// # Arguments
+///
+/// * `username` - The Origin username of the player
+/// * `api_key` - The API key for https://apexlegendsstatus.com
+///
+/// # Examples
+/// ```
+/// // This example will fail if the API returns the 429 error code (too many requests)
+/// match apex_legends::get_user(String::from(&user_name), &api_key).await {
+///    Ok(data) => {
+///        println!(
+///            "You are level {}, and you have {} kills.",
+///            data.global.level, data.stats.br_kills.value
+///        );
+///    }
+///    Err(e) => {
+///        println!("there was an error!: {}", e);
+///    }
+/// }
+/// ```
 pub async fn get_user(username: String, api_key: &str) -> Result<data_types::ApexUser, String> {
     match http::get_request(format!(
         "https://api.mozambiquehe.re/bridge?version=5&platform=PC&player={}&auth={}",
@@ -12,10 +135,22 @@ pub async fn get_user(username: String, api_key: &str) -> Result<data_types::Ape
             Ok(data) => Ok(data),
             Err(e) => Err(format!("{}", e)),
         },
-        Err(_) => Err("There was an error getting your profile.".to_string()),
+        Err(e) => {
+            if let Some(code) = e.0.status() {
+                handle_error::<data_types::ApexUser>(code)
+            } else {
+                Err(format!("{}", e.0))
+            }
+        }
     }
 }
 
+/// Gets information about the recent games.
+/// You must be whitelisted to use this API. It has a strict limit of 5 uniques players queried per hour.
+/// See https://apexlegendsapi.com/#match-history
+///
+/// * `user_id` - The player's UID
+/// * `api_key` - The API key for https://apexlegendsstatus.com
 pub async fn get_recent_games(
     user_id: String,
     api_key: &str,
@@ -30,7 +165,59 @@ pub async fn get_recent_games(
             Ok(data) => Ok(data),
             Err(e) => Err(format!("{}", e)),
         },
-        Err(_) => Err("There was an error getting your recent matches.".to_string()),
+        Err(e) => {
+            if let Some(code) = e.0.status() {
+                handle_error::<Vec<data_types::ApexGame>>(code)
+            } else {
+                Err("There was an error getting your recent matches.".to_string())
+            }
+        }
+    }
+}
+
+/// Returns a player's UID from a given name, but also works with Playstation and Xbox players
+/// See https://apexlegendsapi.com/#name-to-uid
+///
+/// ## Warning
+/// This function does not work as intended:
+///    It will not retry because the API returns 200 OK instead of code 429,
+///    so there is no way to check if error 429 has occurred
+///
+/// # Parameters
+/// * `user_id` - The player's UID
+/// * `api_key` - The API key for https://apexlegendsstatus.com
+/// * `retry` - Wether to retry after a timeout or error out immediately
+pub async fn get_uid_from_username_retry(
+    username: String,
+    api_key: &str,
+    retry: bool,
+) -> Result<data_types::ApexProfile, String> {
+    match http::get_request(format!(
+        "https://api.mozambiquehe.re/nametouid?player={}&platform=PC&auth={}",
+        username, api_key
+    ))
+    .await
+    {
+        Ok(resp) => match serde_json::from_str(&resp) {
+            Ok(data) => Ok(data),
+            Err(e) => match serde_json::from_str::<data_types::ApexError>(&resp) {
+                Ok(err) => Err(err.message),
+                Err(_) => Err(format!("{}", e)),
+            },
+        },
+        Err(e) => {
+            if let Some(code) = e.0.status() {
+                if code == StatusCode::TOO_MANY_REQUESTS && retry {
+                    tokio::time::sleep(Duration::from_secs_f32(get_rate(e.1))).await;
+
+                    get_uid_from_username(username, api_key).await
+                } else {
+                    handle_error::<data_types::ApexProfile>(code)
+                }
+            } else {
+                Err("There was an error getting the user id.".to_string())
+            }
+        }
     }
 }
 
@@ -46,9 +233,48 @@ pub async fn get_uid_from_username(
     {
         Ok(resp) => match serde_json::from_str(&resp) {
             Ok(data) => Ok(data),
-            Err(e) => Err(format!("{}", e)),
+            Err(e) => match serde_json::from_str::<data_types::ApexError>(&resp) {
+                Ok(err) => Err(err.message),
+                Err(_) => Err(format!("{}", e)),
+            },
         },
-        Err(_) => Err("There was an error getting the user id.".to_string()),
+        Err(e) => {
+            if let Some(code) = e.0.status() {
+                handle_error::<data_types::ApexProfile>(code)
+            } else {
+                Err("There was an error getting the user id.".to_string())
+            }
+        }
+    }
+}
+
+pub async fn get_map_rotation_retry(
+    api_key: &str,
+    retry: bool,
+) -> Result<data_types::ApexMapRotation, String> {
+    match http::get_request(format!(
+        "https://api.mozambiquehe.re/maprotation?version=2&auth={}",
+        api_key
+    ))
+    .await
+    {
+        Ok(resp) => match serde_json::from_str(&resp) {
+            Ok(data) => Ok(data),
+            Err(_) => Err("Unable to deserialize JSON.".to_string()),
+        },
+        Err(e) => {
+            if let Some(code) = e.0.status() {
+                if code == StatusCode::TOO_MANY_REQUESTS && retry {
+                    tokio::time::sleep(Duration::from_secs_f32(get_rate(e.1))).await;
+
+                    get_map_rotation(api_key).await
+                } else {
+                    handle_error::<data_types::ApexMapRotation>(code)
+                }
+            } else {
+                Err("There was an error getting the map rotation.".to_string())
+            }
+        }
     }
 }
 
@@ -63,6 +289,12 @@ pub async fn get_map_rotation(api_key: &str) -> Result<data_types::ApexMapRotati
             Ok(data) => Ok(data),
             Err(_) => Err("Unable to deserialize JSON.".to_string()),
         },
-        Err(_) => Err("There was an error getting the map rotation.".to_string()),
+        Err(e) => {
+            if let Some(code) = e.0.status() {
+                handle_error::<data_types::ApexMapRotation>(code)
+            } else {
+                Err("There was an error getting the map rotation.".to_string())
+            }
+        }
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -11,7 +11,10 @@ mod tests {
 
         match apex_legends::get_user(user_name, &api_key).await {
             Ok(data) => {
-                println!("You are level {}, and you have {} kills.", data.global.level, data.stats.br_kills.value);
+                println!(
+                    "You are level {}, and you have {} kills.",
+                    data.global.level, data.stats.br_kills.value
+                );
 
                 assert!(true)
             }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,0 +1,27 @@
+#[cfg(test)]
+mod tests {
+    use std::env;
+
+    #[tokio::test]
+    async fn main() {
+        dotenv::dotenv().expect("Could not load .env file");
+
+        let user_name = env::var("USERNAME").expect("Expected key USERNAME");
+        let api_key = env::var("API_KEY").expect("Expected key API_KEY");
+
+        match apex_legends::get_user(user_name, &api_key)
+            .await
+        {
+            Ok(data) => {
+                println!("You are level {}.", data.global.level);
+
+                assert!(true)
+            }
+            Err(e) => {
+                println!("there was an error!: {}", e);
+
+                assert!(false)
+            }
+        }
+    }
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,28 +1,111 @@
 #[cfg(test)]
 mod tests {
+    use apex_legends::data_types;
     use std::env;
 
+    fn print_data<T>(res: Result<T, String>, f: fn(T) -> String) -> bool {
+        match res {
+            Ok(data) => {
+                println!("{}", f(data));
+
+                true
+            }
+            Err(e) => {
+                println!("there was an error!: {}", e);
+
+                false
+            }
+        }
+    }
+
     #[tokio::test]
-    async fn main() {
+    async fn user() {
         dotenv::dotenv().expect("Could not load .env file");
 
         let user_name = env::var("USERNAME").expect("Expected key USERNAME");
         let api_key = env::var("API_KEY").expect("Expected key API_KEY");
 
-        match apex_legends::get_user(user_name, &api_key).await {
-            Ok(data) => {
-                println!(
-                    "You are level {}, and you have {} kills.",
-                    data.global.level, data.stats.br_kills.value
-                );
+        assert!(
+            print_data::<data_types::ApexUser>(
+                apex_legends::get_user_retry(String::from(&user_name), &api_key, true).await,
+                |data| {
+                    format!(
+                        "You are level {}, and you have {} kills.",
+                        data.global.level, data.stats.br_kills.value
+                    )
+                },
+            ),
+            "get_user_retry"
+        );
 
-                assert!(true)
-            }
-            Err(e) => {
-                println!("there was an error!: {}", e);
+        assert!(
+            print_data::<data_types::ApexUser>(
+                apex_legends::get_user_retry(String::from(&user_name), &api_key, true).await,
+                |data| {
+                    format!(
+                        "You are level {}, and you have {} kills.",
+                        data.global.level, data.stats.br_kills.value
+                    )
+                },
+            ),
+            "get_user_retry"
+        );
+    }
+    #[tokio::test]
+    async fn uid() {
+        dotenv::dotenv().expect("Could not load .env file");
 
-                assert!(false)
-            }
-        }
+        let user_name = env::var("USERNAME").expect("Expected key USERNAME");
+        let api_key = env::var("API_KEY").expect("Expected key API_KEY");
+
+        assert!(
+            print_data::<data_types::ApexProfile>(
+                apex_legends::get_uid_from_username_retry(String::from(&user_name), &api_key, true)
+                    .await,
+                |data| format!("Your UID is {}", data.uid),
+            ),
+            "get_uid_from_username_retry"
+        );
+
+        assert!(
+            print_data::<data_types::ApexProfile>(
+                apex_legends::get_uid_from_username_retry(String::from(&user_name), &api_key, true)
+                    .await,
+                |data| format!("Your UID is {}", data.uid),
+            ),
+            "get_uid_from_username_retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn map_rotation() {
+        dotenv::dotenv().expect("Could not load .env file");
+
+        let api_key = env::var("API_KEY").expect("Expected key API_KEY");
+
+        assert!(
+            print_data::<data_types::ApexMapRotation>(
+                apex_legends::get_map_rotation_retry(&api_key, true).await,
+                |data| {
+                    format!(
+                        "The current ranked map is {}",
+                        data.arenas_ranked.current.map
+                    )
+                },
+            ),
+            "get_map_rotation_retry"
+        );
+        assert!(
+            print_data::<data_types::ApexMapRotation>(
+                apex_legends::get_map_rotation_retry(&api_key, true).await,
+                |data| {
+                    format!(
+                        "The current ranked map is {}",
+                        data.arenas_ranked.current.map
+                    )
+                },
+            ),
+            "get_map_rotation_retry"
+        );
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -9,9 +9,7 @@ mod tests {
         let user_name = env::var("USERNAME").expect("Expected key USERNAME");
         let api_key = env::var("API_KEY").expect("Expected key API_KEY");
 
-        match apex_legends::get_user(user_name, &api_key)
-            .await
-        {
+        match apex_legends::get_user(user_name, &api_key).await {
             Ok(data) => {
                 println!("You are level {}.", data.global.level);
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use apex_legends::data_types;
+    use apex_legends_api::data_types;
     use std::env;
 
     fn print_data<T>(res: Result<T, String>, f: fn(T) -> String) -> bool {
@@ -27,7 +27,7 @@ mod tests {
 
         assert!(
             print_data::<data_types::ApexUser>(
-                apex_legends::get_user_retry(String::from(&user_name), &api_key, true).await,
+                apex_legends_api::get_user_retry(String::from(&user_name), &api_key, true).await,
                 |data| {
                     format!(
                         "You are level {}, and you have {} kills.",
@@ -40,7 +40,7 @@ mod tests {
 
         assert!(
             print_data::<data_types::ApexUser>(
-                apex_legends::get_user_retry(String::from(&user_name), &api_key, true).await,
+                apex_legends_api::get_user_retry(String::from(&user_name), &api_key, true).await,
                 |data| {
                     format!(
                         "You are level {}, and you have {} kills.",
@@ -60,8 +60,12 @@ mod tests {
 
         assert!(
             print_data::<data_types::ApexProfile>(
-                apex_legends::get_uid_from_username_retry(String::from(&user_name), &api_key, true)
-                    .await,
+                apex_legends_api::get_uid_from_username_retry(
+                    String::from(&user_name),
+                    &api_key,
+                    true
+                )
+                .await,
                 |data| format!("Your UID is {}", data.uid),
             ),
             "get_uid_from_username_retry"
@@ -69,8 +73,12 @@ mod tests {
 
         assert!(
             print_data::<data_types::ApexProfile>(
-                apex_legends::get_uid_from_username_retry(String::from(&user_name), &api_key, true)
-                    .await,
+                apex_legends_api::get_uid_from_username_retry(
+                    String::from(&user_name),
+                    &api_key,
+                    true
+                )
+                .await,
                 |data| format!("Your UID is {}", data.uid),
             ),
             "get_uid_from_username_retry"
@@ -85,7 +93,7 @@ mod tests {
 
         assert!(
             print_data::<data_types::ApexMapRotation>(
-                apex_legends::get_map_rotation_retry(&api_key, true).await,
+                apex_legends_api::get_map_rotation_retry(&api_key, true).await,
                 |data| {
                     format!(
                         "The current ranked map is {}",
@@ -97,7 +105,7 @@ mod tests {
         );
         assert!(
             print_data::<data_types::ApexMapRotation>(
-                apex_legends::get_map_rotation_retry(&api_key, true).await,
+                apex_legends_api::get_map_rotation_retry(&api_key, true).await,
                 |data| {
                     format!(
                         "The current ranked map is {}",

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -11,7 +11,7 @@ mod tests {
 
         match apex_legends::get_user(user_name, &api_key).await {
             Ok(data) => {
-                println!("You are level {}.", data.global.level);
+                println!("You are level {}, and you have {} kills.", data.global.level, data.stats.br_kills.value);
 
                 assert!(true)
             }


### PR DESCRIPTION
## Changes

1. A new value (`#[serde(alias = "total")]  pub stats: ApexStats`) for the `ApexUser`
2. A simple test, which is basically the example in the README.md. This is to check that future features work.
3. A workflow to check if the code is correctly formatted.

---

### 1. ApexStats

The API returns some extra information that wasn't being captured. It contains information such as kills, damage, etc. And it also contains some other values that I did not bother to include because they are seasonal.

This is the struct (Stat just contains "name" and "value"):
```Rust
pub struct ApexStats {
    pub br_kills: Stat<i32>,
    pub br_damage: Stat<i32>,
    pub arenas_damage: Stat<i32>,
    pub games_played: Stat<i32>,
    pub kd: Stat<String>,
}
```

### 2. The test

The test is just the example in the readme:
```Rust
dotenv::dotenv().expect("Could not load .env file");

let user_name = env::var("USERNAME").expect("Expected key USERNAME");
let api_key = env::var("API_KEY").expect("Expected key API_KEY");

match apex_legends::get_user(user_name, &api_key).await {
    Ok(data) => {
        println!("You are level {}, and you have {} kills.", data.global.level, data.stats.br_kills.value);

        assert!(true)
    }
    Err(e) => {
        println!("there was an error!: {}", e);

        assert!(false)
    }
}
```

You might observe that I load the private values as environment variables. 

This is for privacy and security reasons, obviously, but it also implies that I cannot create a github action for tests. If you want to do that, you will need to create a Secret and configure the action.

**Note**: I recommend running the tests with `cargo test -- --nocapture`, so that you can see the output of the `println` of the test.

### 3. Github Actions

It is just a simple action that runs `cargo fmt` and fails if it was not run. 

## Note

You should run `cargo fmt` before each commit
