### PR TITLE
API retry on too_many_requests (code 429)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,29 @@
+name: Rust
+
+on:
+  push:
+    branches: [ main ]
+    tags:
+      - '*'
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install latest stable
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt 
+
+      - name: Check code format
+        run: cargo fmt --all -- --check

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /src/main.rs
+.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,11 +6,23 @@ version = 3
 name = "apex_legends"
 version = "0.1.2"
 dependencies = [
+ "async-recursion",
  "dotenv",
  "reqwest",
  "serde",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cda8f4bcc10624c4e85bc66b3f452cca98cfa5ca002dc83a16aad2367641bea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ version = 3
 name = "apex_legends"
 version = "0.1.2"
 dependencies = [
+ "dotenv",
  "reqwest",
  "serde",
  "serde_json",
@@ -69,6 +70,12 @@ name = "core-foundation-sys"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+
+[[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "encoding_rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ tokio = { version = "1.0", features = ["full"] }
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0"
+async-recursion = "1.0.0"
 
 [dev-dependencies]
 dotenv = "0.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ tokio = { version = "1.0", features = ["full"] }
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0"
+dotenv = "0.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,6 @@ tokio = { version = "1.0", features = ["full"] }
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0"
+
+[dev-dependencies]
 dotenv = "0.15.0"

--- a/src/data_types.rs
+++ b/src/data_types.rs
@@ -185,8 +185,8 @@ pub struct ApexMapRotationItem {
 
 #[derive(Deserialize, Debug)]
 pub struct Stat<V> {
-    name: String,
-    value: V,
+    pub name: String,
+    pub value: V,
 }
 
 #[derive(Deserialize, Debug)]

--- a/src/data_types.rs
+++ b/src/data_types.rs
@@ -1,4 +1,4 @@
-use serde::{ Deserialize };
+use serde::Deserialize;
 
 #[derive(Deserialize)]
 pub struct ApexUser {
@@ -37,13 +37,13 @@ pub struct ApexRealtime {
     #[serde(alias = "selectedLegend")]
     pub selected_legend: String,
     #[serde(alias = "currentState")]
-    pub current_state: String
+    pub current_state: String,
 }
 
 #[derive(Deserialize)]
 pub struct ApexBattlepass {
     pub level: String,
-    pub history: ApexBattlepassHistory
+    pub history: ApexBattlepassHistory,
 }
 
 #[derive(Deserialize)]
@@ -57,7 +57,7 @@ pub struct ApexBattlepassHistory {
     pub season7: i32,
     pub season8: i32,
     pub season9: i32,
-    pub season10: i32
+    pub season10: i32,
 }
 
 #[derive(Deserialize)]
@@ -71,7 +71,7 @@ pub struct ApexRank {
     #[serde(alias = "rankImg")]
     pub rank_img: String,
     #[serde(alias = "rankedSeason")]
-    pub ranked_season: String
+    pub ranked_season: String,
 }
 
 #[derive(Deserialize)]
@@ -81,7 +81,7 @@ pub struct ApexBans {
     #[serde(alias = "remainingSeconds")]
     pub remaining_seconds: i32,
     #[serde(alias = "last_banReason")]
-    pub last_ban_reason: String
+    pub last_ban_reason: String,
 }
 
 #[derive(Deserialize, Debug)]
@@ -108,7 +108,7 @@ pub struct ApexGame {
     pub arenas_score_change: i32,
     #[serde(alias = "ArenasScore")]
     pub arenas_score: i32,
-    pub cosmetics: ApexCosmetics
+    pub cosmetics: ApexCosmetics,
 }
 
 #[derive(Deserialize, Debug)]
@@ -124,15 +124,14 @@ pub struct ApexCosmetics {
     #[serde(alias = "frameRarity")]
     pub frame_rarity: String,
     #[serde(alias = "introRarity")]
-    pub intro_rarity: String
-    
+    pub intro_rarity: String,
 }
 
 #[derive(Deserialize, Debug)]
 pub struct ApexGameData {
     pub key: String,
     pub value: i32,
-    pub name: Option<String>
+    pub name: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -140,7 +139,7 @@ pub struct ApexProfile {
     pub name: String,
     pub uid: String,
     pub pid: String,
-    pub avatar: String
+    pub avatar: String,
 }
 
 #[derive(Deserialize, Debug)]
@@ -149,7 +148,7 @@ pub struct ApexMapRotation {
     pub arenas: ApexMapRotationData,
     pub ranked: ApexRankedMapRotationData,
     #[serde(alias = "arenasRanked")]
-    pub arenas_ranked: ApexMapRotationData
+    pub arenas_ranked: ApexMapRotationData,
 }
 
 #[derive(Deserialize, Debug)]
@@ -163,7 +162,6 @@ pub struct ApexRankedMapRotationData {
     pub current: ApexRankedMapRotationItem,
     pub next: ApexRankedMapRotationItem,
 }
-
 
 #[derive(Deserialize, Debug)]
 pub struct ApexRankedMapRotationItem {
@@ -182,7 +180,7 @@ pub struct ApexMapRotationItem {
     #[serde(alias = "DurationInSecs")]
     pub duration_in_seconds: i32,
     #[serde(alias = "DurationInMinutes")]
-    pub duration_in_minutes: i32
+    pub duration_in_minutes: i32,
 }
 
 #[derive(Deserialize, Debug)]

--- a/src/data_types.rs
+++ b/src/data_types.rs
@@ -3,9 +3,10 @@ use serde::{ Deserialize };
 #[derive(Deserialize)]
 pub struct ApexUser {
     pub global: ApexGlobal,
-    pub realtime: ApexRealtime
+    pub realtime: ApexRealtime,
+    #[serde(alias = "total")]
+    pub stats: ApexStats,
 }
-
 #[derive(Deserialize)]
 pub struct ApexGlobal {
     pub name: String,
@@ -182,4 +183,21 @@ pub struct ApexMapRotationItem {
     pub duration_in_seconds: i32,
     #[serde(alias = "DurationInMinutes")]
     pub duration_in_minutes: i32
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Stat<V> {
+    name: String,
+    value: V,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ApexStats {
+    #[serde(alias = "kills")]
+    pub br_kills: Stat<i32>,
+    #[serde(alias = "damage")]
+    pub br_damage: Stat<i32>,
+    pub arenas_damage: Stat<i32>,
+    pub games_played: Stat<i32>,
+    pub kd: Stat<String>,
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -3,7 +3,7 @@ use reqwest;
 pub async fn get_request(url: String) -> Result<String, reqwest::Error> {
     match reqwest::get(url).await?.text().await {
         Ok(data) => Ok(data),
-        Err(e) => Err(e)
+        Err(e) => Err(e),
     }
 }
 
@@ -12,6 +12,6 @@ pub async fn post_request(url: &str, body: String) -> Result<String, reqwest::Er
 
     match client.post(url).body(body).send().await?.text().await {
         Ok(data) => Ok(data),
-        Err(e) => Err(e)
+        Err(e) => Err(e),
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,8 +1,13 @@
 use reqwest;
 
 pub async fn get_request(url: String) -> Result<String, reqwest::Error> {
-    match reqwest::get(url).await?.text().await {
-        Ok(data) => Ok(data),
+    let response = reqwest::get(url).await?;
+
+    match response.error_for_status() {
+        Ok(res) => match res.text().await {
+            Ok(text) => Ok(text),
+            Err(e) => Err(e),
+        },
         Err(e) => Err(e),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub async fn get_user_retry(
                 } else {
                     Err(format!("{}", e))
                 }
-            }else {
+            } else {
                 Err(format!("There was an error getting your profile: {}", e))
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,50 +1,68 @@
-mod http;
 mod data_types;
+mod http;
 
 pub async fn get_user(username: String, api_key: &str) -> Result<data_types::ApexUser, String> {
-    match http::get_request(format!("https://api.mozambiquehe.re/bridge?version=5&platform=PC&player={}&auth={}", username, api_key)).await {
-        Ok(resp) => {
-            match serde_json::from_str(&resp) {
-                Ok(data) => Ok(data),
-                Err(e) => Err(format!("{}", e))
-            }
+    match http::get_request(format!(
+        "https://api.mozambiquehe.re/bridge?version=5&platform=PC&player={}&auth={}",
+        username, api_key
+    ))
+    .await
+    {
+        Ok(resp) => match serde_json::from_str(&resp) {
+            Ok(data) => Ok(data),
+            Err(e) => Err(format!("{}", e)),
         },
-        Err(_) => Err("There was an error getting your profile.".to_string())
+        Err(_) => Err("There was an error getting your profile.".to_string()),
     }
 }
 
-pub async fn get_recent_games(user_id: String, api_key: &str) -> Result<Vec<data_types::ApexGame>, String> {
-    match http::get_request(format!("https://api.mozambiquehe.re/games?auth={}&uid={}", api_key, user_id)).await {
-        Ok(resp) => {
-            match serde_json::from_str(&resp) {
-                Ok(data) => Ok(data),
-                Err(e) => Err(format!("{}", e))
-            }
+pub async fn get_recent_games(
+    user_id: String,
+    api_key: &str,
+) -> Result<Vec<data_types::ApexGame>, String> {
+    match http::get_request(format!(
+        "https://api.mozambiquehe.re/games?auth={}&uid={}",
+        api_key, user_id
+    ))
+    .await
+    {
+        Ok(resp) => match serde_json::from_str(&resp) {
+            Ok(data) => Ok(data),
+            Err(e) => Err(format!("{}", e)),
         },
-        Err(_) => Err("There was an error getting your recent matches.".to_string())
+        Err(_) => Err("There was an error getting your recent matches.".to_string()),
     }
 }
 
-pub async fn get_uid_from_username(username: String, api_key: &str) -> Result<data_types::ApexProfile, String> {
-    match http::get_request(format!("https://api.mozambiquehe.re/nametouid?player={}&platform=PC&auth={}", username, api_key)).await {
-        Ok(resp) => {
-            match serde_json::from_str(&resp) {
-                Ok(data) => Ok(data),
-                Err(e) => Err(format!("{}", e))
-            }
+pub async fn get_uid_from_username(
+    username: String,
+    api_key: &str,
+) -> Result<data_types::ApexProfile, String> {
+    match http::get_request(format!(
+        "https://api.mozambiquehe.re/nametouid?player={}&platform=PC&auth={}",
+        username, api_key
+    ))
+    .await
+    {
+        Ok(resp) => match serde_json::from_str(&resp) {
+            Ok(data) => Ok(data),
+            Err(e) => Err(format!("{}", e)),
         },
-        Err(_) => Err("There was an error getting the user id.".to_string())
+        Err(_) => Err("There was an error getting the user id.".to_string()),
     }
 }
 
 pub async fn get_map_rotation(api_key: &str) -> Result<data_types::ApexMapRotation, String> {
-    match http::get_request(format!("https://api.mozambiquehe.re/maprotation?version=2&auth={}", api_key)).await {
-        Ok(resp) => {
-            match serde_json::from_str(&resp) {
-                Ok(data) => Ok(data),
-                Err(_) => Err("Unable to deserialize JSON.".to_string())
-            }
+    match http::get_request(format!(
+        "https://api.mozambiquehe.re/maprotation?version=2&auth={}",
+        api_key
+    ))
+    .await
+    {
+        Ok(resp) => match serde_json::from_str(&resp) {
+            Ok(data) => Ok(data),
+            Err(_) => Err("Unable to deserialize JSON.".to_string()),
         },
-        Err(_) => Err("There was an error getting the map rotation.".to_string())
+        Err(_) => Err("There was an error getting the map rotation.".to_string()),
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -11,7 +11,10 @@ mod tests {
 
         match apex_legends::get_user(user_name, &api_key).await {
             Ok(data) => {
-                println!("You are level {}, and you have {} kills.", data.global.level, data.stats.br_kills.value);
+                println!(
+                    "You are level {}, and you have {} kills.",
+                    data.global.level, data.stats.br_kills.value
+                );
 
                 assert!(true)
             }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,0 +1,27 @@
+#[cfg(test)]
+mod tests {
+    use std::env;
+
+    #[tokio::test]
+    async fn main() {
+        dotenv::dotenv().expect("Could not load .env file");
+
+        let user_name = env::var("USERNAME").expect("Expected key USERNAME");
+        let api_key = env::var("API_KEY").expect("Expected key API_KEY");
+
+        match apex_legends::get_user(user_name, &api_key)
+            .await
+        {
+            Ok(data) => {
+                println!("You are level {}.", data.global.level);
+
+                assert!(true)
+            }
+            Err(e) => {
+                println!("there was an error!: {}", e);
+
+                assert!(false)
+            }
+        }
+    }
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -9,7 +9,23 @@ mod tests {
         let user_name = env::var("USERNAME").expect("Expected key USERNAME");
         let api_key = env::var("API_KEY").expect("Expected key API_KEY");
 
-        match apex_legends::get_user(user_name, &api_key).await {
+        match apex_legends::get_user_retry(String::from(&user_name), &api_key,true).await {
+            Ok(data) => {
+                println!(
+                    "You are level {}, and you have {} kills.",
+                    data.global.level, data.stats.br_kills.value
+                );
+
+                assert!(true)
+            }
+            Err(e) => {
+                println!("there was an error!: {}", e);
+
+                assert!(false)
+            }
+        }
+
+        match apex_legends::get_user_retry(user_name, &api_key, true).await {
             Ok(data) => {
                 println!(
                     "You are level {}, and you have {} kills.",

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -9,9 +9,7 @@ mod tests {
         let user_name = env::var("USERNAME").expect("Expected key USERNAME");
         let api_key = env::var("API_KEY").expect("Expected key API_KEY");
 
-        match apex_legends::get_user(user_name, &api_key)
-            .await
-        {
+        match apex_legends::get_user(user_name, &api_key).await {
             Ok(data) => {
                 println!("You are level {}.", data.global.level);
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -9,7 +9,7 @@ mod tests {
         let user_name = env::var("USERNAME").expect("Expected key USERNAME");
         let api_key = env::var("API_KEY").expect("Expected key API_KEY");
 
-        match apex_legends::get_user_retry(String::from(&user_name), &api_key,true).await {
+        match apex_legends::get_user_retry(String::from(&user_name), &api_key, true).await {
             Ok(data) => {
                 println!(
                     "You are level {}, and you have {} kills.",

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -11,7 +11,7 @@ mod tests {
 
         match apex_legends::get_user(user_name, &api_key).await {
             Ok(data) => {
-                println!("You are level {}.", data.global.level);
+                println!("You are level {}, and you have {} kills.", data.global.level, data.stats.br_kills.value);
 
                 assert!(true)
             }


### PR DESCRIPTION
_Note: I know this is not ideal, but this branch contains the changes proposed in PR #1, so this should not be merged until PR #1 is merged, or move [the commit](https://github.com/KasprDev/Apex-Legends-API-Rust/commit/1fd0ab775cf55c8bd7be5f94c64fb204b0de79a9) to a new branch._

## Concept

1. Make a request and wait for response
2. Error if the code is not 200
3. Handle the error and if the code is 429, then:
   a.  Wait 2 seconds
   b. Retry

## Implementation

I'm open to suggestions on improvements on this one.

- The "retry" is achieved through recursion, but since the function is async I had to include the `async-recursion` crate and decorator on the function.
- An extra argument is added to choose if the library should automatically retry
- To maintain compatibility, the function has changed name to `get_user_retry`, and now `get_user` just calls `get_user_retry` with retry set to false.

The test has been updated accordingly by making two consecutive calls to the API.