### PR TITLE
Added documentation, new ways of handling errors, a better way of retrying requests and added more tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,23 +6,11 @@ version = 3
 name = "apex_legends"
 version = "0.1.2"
 dependencies = [
- "async-recursion",
  "dotenv",
  "reqwest",
  "serde",
  "serde_json",
  "tokio",
-]
-
-[[package]]
-name = "async-recursion"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cda8f4bcc10624c4e85bc66b3f452cca98cfa5ca002dc83a16aad2367641bea"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ tokio = { version = "1.0", features = ["full"] }
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0"
-async-recursion = "1.0.0"
 
 [dev-dependencies]
 dotenv = "0.15.0"

--- a/src/data_types.rs
+++ b/src/data_types.rs
@@ -199,3 +199,9 @@ pub struct ApexStats {
     pub games_played: Stat<i32>,
     pub kd: Stat<String>,
 }
+
+#[derive(Deserialize, Debug)]
+pub struct ApexError {
+    #[serde(alias = "Error")]
+    pub message: String,
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,14 +1,21 @@
-use reqwest;
+use reqwest::{self, header::HeaderMap};
 
-pub async fn get_request(url: String) -> Result<String, reqwest::Error> {
-    let response = reqwest::get(url).await?;
+pub async fn get_request(url: String) -> Result<String, (reqwest::Error, Option<HeaderMap>)> {
+    let response = reqwest::get(url).await;
 
-    match response.error_for_status() {
-        Ok(res) => match res.text().await {
-            Ok(text) => Ok(text),
-            Err(e) => Err(e),
-        },
-        Err(e) => Err(e),
+    match response {
+        Ok(res) => {
+            let headers = res.headers().clone();
+
+            match res.error_for_status() {
+                Ok(r) => Ok(r
+                    .text()
+                    .await
+                    .expect("Could not retrieve text from the successful request")),
+                Err(e) => Err((e, Some(headers))), //Err((, Some(headers))),
+            }
+        }
+        Err(e) => Err((e, None)),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,31 @@
 use std::time::Duration;
 
-use async_recursion::async_recursion;
 use reqwest::StatusCode;
 
 mod data_types;
 mod http;
 
-#[async_recursion]
+/// Time (in seconds) to wait after the error TOO_MANY_REQUESTS (429)
+pub const WAIT_TIME: f32 = 2.5;
+
+/// Simple function to standarize error messages given a Status Code
+fn handle_error<T>(status: StatusCode) -> Result<T, String> {
+    // Documentation: https://apexlegendsapi.com/#errors
+    match status {
+        StatusCode::TOO_MANY_REQUESTS => Err(String::from(
+            "Too many requests: wait 1 or 2 seconds please",
+        )),
+        StatusCode::UNAUTHORIZED => Err(String::from(
+            "The API key is incorrect, please contact the bot administrator",
+        )),
+        StatusCode::NOT_FOUND => Err(String::from("Either the apexlegendsapi.com")),
+        StatusCode::INTERNAL_SERVER_ERROR => {
+            Err(String::from("There was an internal server error"))
+        }
+        _ => Err(format!("{}", status)),
+    }
+}
+
 pub async fn get_user_retry(
     username: String,
     api_key: &str,
@@ -23,16 +42,16 @@ pub async fn get_user_retry(
             Err(e) => Err(format!("{}", e)),
         },
         Err(e) => {
-            if let Some(status) = e.status() {
-                if status == StatusCode::TOO_MANY_REQUESTS && retry {
-                    tokio::time::sleep(Duration::from_secs_f32(2.5)).await;
+            if let Some(code) = e.status() {
+                if code == StatusCode::TOO_MANY_REQUESTS && retry {
+                    tokio::time::sleep(Duration::from_secs_f32(WAIT_TIME)).await;
 
-                    return get_user_retry(username, api_key, false).await;
+                    get_user(username, api_key).await
                 } else {
-                    Err(format!("{}", e))
+                    handle_error::<data_types::ApexUser>(code)
                 }
             } else {
-                Err(format!("There was an error getting your profile: {}", e))
+                Err(format!("{}", e))
             }
         }
     }
@@ -49,10 +68,46 @@ pub async fn get_user(username: String, api_key: &str) -> Result<data_types::Ape
             Ok(data) => Ok(data),
             Err(e) => Err(format!("{}", e)),
         },
-        Err(e) => Err(format!("There was an error getting your profile: {}", e)),
+        Err(e) => {
+            if let Some(code) = e.status() {
+                handle_error::<data_types::ApexUser>(code)
+            } else {
+                Err(format!("{}", e))
+            }
+        }
     }
 }
 
+pub async fn get_recent_games_retry(
+    user_id: String,
+    api_key: &str,
+    retry: bool,
+) -> Result<Vec<data_types::ApexGame>, String> {
+    match http::get_request(format!(
+        "https://api.mozambiquehe.re/games?auth={}&uid={}",
+        api_key, user_id
+    ))
+    .await
+    {
+        Ok(resp) => match serde_json::from_str(&resp) {
+            Ok(data) => Ok(data),
+            Err(e) => Err(format!("{}", e)),
+        },
+        Err(e) => {
+            if let Some(code) = e.status() {
+                if code == StatusCode::TOO_MANY_REQUESTS && retry {
+                    tokio::time::sleep(Duration::from_secs_f32(WAIT_TIME)).await;
+
+                    get_recent_games(user_id, api_key).await
+                } else {
+                    handle_error::<Vec<data_types::ApexGame>>(code)
+                }
+            } else {
+                Err("There was an error getting your recent matches.".to_string())
+            }
+        }
+    }
+}
 pub async fn get_recent_games(
     user_id: String,
     api_key: &str,
@@ -67,7 +122,44 @@ pub async fn get_recent_games(
             Ok(data) => Ok(data),
             Err(e) => Err(format!("{}", e)),
         },
-        Err(_) => Err("There was an error getting your recent matches.".to_string()),
+        Err(e) => {
+            if let Some(code) = e.status() {
+                handle_error::<Vec<data_types::ApexGame>>(code)
+            } else {
+                Err("There was an error getting your recent matches.".to_string())
+            }
+        }
+    }
+}
+
+pub async fn get_uid_from_username_retry(
+    username: String,
+    api_key: &str,
+    retry: bool,
+) -> Result<data_types::ApexProfile, String> {
+    match http::get_request(format!(
+        "https://api.mozambiquehe.re/nametouid?player={}&platform=PC&auth={}",
+        username, api_key
+    ))
+    .await
+    {
+        Ok(resp) => match serde_json::from_str(&resp) {
+            Ok(data) => Ok(data),
+            Err(e) => Err(format!("{}", e)),
+        },
+        Err(e) => {
+            if let Some(code) = e.status() {
+                if code == StatusCode::TOO_MANY_REQUESTS && retry {
+                    tokio::time::sleep(Duration::from_secs_f32(WAIT_TIME)).await;
+
+                    get_uid_from_username(username, api_key).await
+                } else {
+                    handle_error::<data_types::ApexProfile>(code)
+                }
+            } else {
+                Err("There was an error getting the user id.".to_string())
+            }
+        }
     }
 }
 
@@ -85,7 +177,43 @@ pub async fn get_uid_from_username(
             Ok(data) => Ok(data),
             Err(e) => Err(format!("{}", e)),
         },
-        Err(_) => Err("There was an error getting the user id.".to_string()),
+        Err(e) => {
+            if let Some(code) = e.status() {
+                handle_error::<data_types::ApexProfile>(code)
+            } else {
+                Err("There was an error getting the user id.".to_string())
+            }
+        }
+    }
+}
+
+pub async fn get_map_rotation_retry(
+    api_key: &str,
+    retry: bool,
+) -> Result<data_types::ApexMapRotation, String> {
+    match http::get_request(format!(
+        "https://api.mozambiquehe.re/maprotation?version=2&auth={}",
+        api_key
+    ))
+    .await
+    {
+        Ok(resp) => match serde_json::from_str(&resp) {
+            Ok(data) => Ok(data),
+            Err(_) => Err("Unable to deserialize JSON.".to_string()),
+        },
+        Err(e) => {
+            if let Some(code) = e.status() {
+                if code == StatusCode::TOO_MANY_REQUESTS && retry {
+                    tokio::time::sleep(Duration::from_secs_f32(WAIT_TIME)).await;
+
+                    get_map_rotation(api_key).await
+                } else {
+                    handle_error::<data_types::ApexMapRotation>(code)
+                }
+            } else {
+                Err("There was an error getting the map rotation.".to_string())
+            }
+        }
     }
 }
 
@@ -100,6 +228,12 @@ pub async fn get_map_rotation(api_key: &str) -> Result<data_types::ApexMapRotati
             Ok(data) => Ok(data),
             Err(_) => Err("Unable to deserialize JSON.".to_string()),
         },
-        Err(_) => Err("There was an error getting the map rotation.".to_string()),
+        Err(e) => {
+            if let Some(code) = e.status() {
+                handle_error::<data_types::ApexMapRotation>(code)
+            } else {
+                Err("There was an error getting the map rotation.".to_string())
+            }
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,12 @@
 use std::time::Duration;
 
-use reqwest::StatusCode;
+use reqwest::{header::HeaderMap, StatusCode};
 
-mod data_types;
+pub mod data_types;
 mod http;
 
-/// Time (in seconds) to wait after the error TOO_MANY_REQUESTS (429)
-pub const WAIT_TIME: f32 = 2.5;
+/// Default time to wait after a 429 error code
+pub const DEFAULT_RATE: f32 = 3.0;
 
 /// Simple function to standarize error messages given a Status Code
 fn handle_error<T>(status: StatusCode) -> Result<T, String> {
@@ -26,6 +26,48 @@ fn handle_error<T>(status: StatusCode) -> Result<T, String> {
     }
 }
 
+/// Given an optional header, return the value of the header if it exists or DEFAULT_RATE
+/// The header is `x-current-rate`
+fn get_rate(header: Option<HeaderMap>) -> f32 {
+    if let Some(h) = header {
+        if let Some(value) = h.get("x-current-rate") {
+            let default = DEFAULT_RATE.to_string();
+            let string_value = value.to_str().unwrap_or(default.as_str());
+
+            return string_value.parse().unwrap_or(DEFAULT_RATE);
+        } else {
+            return DEFAULT_RATE;
+        }
+    } else {
+        return DEFAULT_RATE;
+    }
+}
+
+/// Gets information about a User. This version automatically retries if the API returns code 429 (too many requests).
+/// For the sleep time it reads the `x-current-rate` header or uses the DEFAULT_RATE
+/// See https://apexlegendsapi.com/#player-statistics
+///
+/// # Arguments
+///
+/// * `username` - The Origin username of the player
+/// * `api_key` - The API key for https://apexlegendsstatus.com
+/// * `retry` - Wether to retry after a timeout or error out immediately
+///
+/// # Examples
+/// ```
+/// // This example automatically handles the 429 error code (too many requests)
+/// match apex_legends::get_user_retry(String::from(&user_name), &api_key, true).await {
+///    Ok(data) => {
+///        println!(
+///            "You are level {}, and you have {} kills.",
+///            data.global.level, data.stats.br_kills.value
+///        );
+///    }
+///    Err(e) => {
+///        println!("there was an error!: {}", e);
+///    }
+/// }
+/// ```
 pub async fn get_user_retry(
     username: String,
     api_key: &str,
@@ -42,21 +84,46 @@ pub async fn get_user_retry(
             Err(e) => Err(format!("{}", e)),
         },
         Err(e) => {
-            if let Some(code) = e.status() {
+            if let Some(code) = e.0.status() {
                 if code == StatusCode::TOO_MANY_REQUESTS && retry {
-                    tokio::time::sleep(Duration::from_secs_f32(WAIT_TIME)).await;
+                    let time = get_rate(e.1);
+
+                    tokio::time::sleep(Duration::from_secs_f32(time)).await;
 
                     get_user(username, api_key).await
                 } else {
                     handle_error::<data_types::ApexUser>(code)
                 }
             } else {
-                Err(format!("{}", e))
+                Err(format!("{}", e.0))
             }
         }
     }
 }
 
+/// Gets information about a User. This version does not handle code 429 (too many requests)
+/// See https://apexlegendsapi.com/#player-statistics
+///
+/// # Arguments
+///
+/// * `username` - The Origin username of the player
+/// * `api_key` - The API key for https://apexlegendsstatus.com
+///
+/// # Examples
+/// ```
+/// // This example will fail if the API returns the 429 error code (too many requests)
+/// match apex_legends::get_user(String::from(&user_name), &api_key).await {
+///    Ok(data) => {
+///        println!(
+///            "You are level {}, and you have {} kills.",
+///            data.global.level, data.stats.br_kills.value
+///        );
+///    }
+///    Err(e) => {
+///        println!("there was an error!: {}", e);
+///    }
+/// }
+/// ```
 pub async fn get_user(username: String, api_key: &str) -> Result<data_types::ApexUser, String> {
     match http::get_request(format!(
         "https://api.mozambiquehe.re/bridge?version=5&platform=PC&player={}&auth={}",
@@ -69,45 +136,21 @@ pub async fn get_user(username: String, api_key: &str) -> Result<data_types::Ape
             Err(e) => Err(format!("{}", e)),
         },
         Err(e) => {
-            if let Some(code) = e.status() {
+            if let Some(code) = e.0.status() {
                 handle_error::<data_types::ApexUser>(code)
             } else {
-                Err(format!("{}", e))
+                Err(format!("{}", e.0))
             }
         }
     }
 }
 
-pub async fn get_recent_games_retry(
-    user_id: String,
-    api_key: &str,
-    retry: bool,
-) -> Result<Vec<data_types::ApexGame>, String> {
-    match http::get_request(format!(
-        "https://api.mozambiquehe.re/games?auth={}&uid={}",
-        api_key, user_id
-    ))
-    .await
-    {
-        Ok(resp) => match serde_json::from_str(&resp) {
-            Ok(data) => Ok(data),
-            Err(e) => Err(format!("{}", e)),
-        },
-        Err(e) => {
-            if let Some(code) = e.status() {
-                if code == StatusCode::TOO_MANY_REQUESTS && retry {
-                    tokio::time::sleep(Duration::from_secs_f32(WAIT_TIME)).await;
-
-                    get_recent_games(user_id, api_key).await
-                } else {
-                    handle_error::<Vec<data_types::ApexGame>>(code)
-                }
-            } else {
-                Err("There was an error getting your recent matches.".to_string())
-            }
-        }
-    }
-}
+/// Gets information about the recent games.
+/// You must be whitelisted to use this API. It has a strict limit of 5 uniques players queried per hour.
+/// See https://apexlegendsapi.com/#match-history
+///
+/// * `user_id` - The player's UID
+/// * `api_key` - The API key for https://apexlegendsstatus.com
 pub async fn get_recent_games(
     user_id: String,
     api_key: &str,
@@ -123,7 +166,7 @@ pub async fn get_recent_games(
             Err(e) => Err(format!("{}", e)),
         },
         Err(e) => {
-            if let Some(code) = e.status() {
+            if let Some(code) = e.0.status() {
                 handle_error::<Vec<data_types::ApexGame>>(code)
             } else {
                 Err("There was an error getting your recent matches.".to_string())
@@ -132,6 +175,18 @@ pub async fn get_recent_games(
     }
 }
 
+/// Returns a player's UID from a given name, but also works with Playstation and Xbox players
+/// See https://apexlegendsapi.com/#name-to-uid
+///
+/// ## Warning
+/// This function does not work as intended:
+///    It will not retry because the API returns 200 OK instead of code 429,
+///    so there is no way to check if error 429 has occurred
+///
+/// # Parameters
+/// * `user_id` - The player's UID
+/// * `api_key` - The API key for https://apexlegendsstatus.com
+/// * `retry` - Wether to retry after a timeout or error out immediately
 pub async fn get_uid_from_username_retry(
     username: String,
     api_key: &str,
@@ -145,12 +200,15 @@ pub async fn get_uid_from_username_retry(
     {
         Ok(resp) => match serde_json::from_str(&resp) {
             Ok(data) => Ok(data),
-            Err(e) => Err(format!("{}", e)),
+            Err(e) => match serde_json::from_str::<data_types::ApexError>(&resp) {
+                Ok(err) => Err(err.message),
+                Err(_) => Err(format!("{}", e)),
+            },
         },
         Err(e) => {
-            if let Some(code) = e.status() {
+            if let Some(code) = e.0.status() {
                 if code == StatusCode::TOO_MANY_REQUESTS && retry {
-                    tokio::time::sleep(Duration::from_secs_f32(WAIT_TIME)).await;
+                    tokio::time::sleep(Duration::from_secs_f32(get_rate(e.1))).await;
 
                     get_uid_from_username(username, api_key).await
                 } else {
@@ -175,10 +233,13 @@ pub async fn get_uid_from_username(
     {
         Ok(resp) => match serde_json::from_str(&resp) {
             Ok(data) => Ok(data),
-            Err(e) => Err(format!("{}", e)),
+            Err(e) => match serde_json::from_str::<data_types::ApexError>(&resp) {
+                Ok(err) => Err(err.message),
+                Err(_) => Err(format!("{}", e)),
+            },
         },
         Err(e) => {
-            if let Some(code) = e.status() {
+            if let Some(code) = e.0.status() {
                 handle_error::<data_types::ApexProfile>(code)
             } else {
                 Err("There was an error getting the user id.".to_string())
@@ -202,9 +263,9 @@ pub async fn get_map_rotation_retry(
             Err(_) => Err("Unable to deserialize JSON.".to_string()),
         },
         Err(e) => {
-            if let Some(code) = e.status() {
+            if let Some(code) = e.0.status() {
                 if code == StatusCode::TOO_MANY_REQUESTS && retry {
-                    tokio::time::sleep(Duration::from_secs_f32(WAIT_TIME)).await;
+                    tokio::time::sleep(Duration::from_secs_f32(get_rate(e.1))).await;
 
                     get_map_rotation(api_key).await
                 } else {
@@ -229,7 +290,7 @@ pub async fn get_map_rotation(api_key: &str) -> Result<data_types::ApexMapRotati
             Err(_) => Err("Unable to deserialize JSON.".to_string()),
         },
         Err(e) => {
-            if let Some(code) = e.status() {
+            if let Some(code) = e.0.status() {
                 handle_error::<data_types::ApexMapRotation>(code)
             } else {
                 Err("There was an error getting the map rotation.".to_string())

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -25,25 +25,31 @@ mod tests {
         let user_name = env::var("USERNAME").expect("Expected key USERNAME");
         let api_key = env::var("API_KEY").expect("Expected key API_KEY");
 
-        assert!(print_data::<data_types::ApexUser>(
-            apex_legends::get_user_retry(String::from(&user_name), &api_key, true).await,
-            |data| {
-                format!(
-                    "You are level {}, and you have {} kills.",
-                    data.global.level, data.stats.br_kills.value
-                )
-            },
-        ), "get_user_retry");
+        assert!(
+            print_data::<data_types::ApexUser>(
+                apex_legends::get_user_retry(String::from(&user_name), &api_key, true).await,
+                |data| {
+                    format!(
+                        "You are level {}, and you have {} kills.",
+                        data.global.level, data.stats.br_kills.value
+                    )
+                },
+            ),
+            "get_user_retry"
+        );
 
-        assert!(print_data::<data_types::ApexUser>(
-            apex_legends::get_user_retry(String::from(&user_name), &api_key, true).await,
-            |data| {
-                format!(
-                    "You are level {}, and you have {} kills.",
-                    data.global.level, data.stats.br_kills.value
-                )
-            },
-        ), "get_user_retry");
+        assert!(
+            print_data::<data_types::ApexUser>(
+                apex_legends::get_user_retry(String::from(&user_name), &api_key, true).await,
+                |data| {
+                    format!(
+                        "You are level {}, and you have {} kills.",
+                        data.global.level, data.stats.br_kills.value
+                    )
+                },
+            ),
+            "get_user_retry"
+        );
     }
     #[tokio::test]
     async fn uid() {
@@ -52,17 +58,23 @@ mod tests {
         let user_name = env::var("USERNAME").expect("Expected key USERNAME");
         let api_key = env::var("API_KEY").expect("Expected key API_KEY");
 
-        assert!(print_data::<data_types::ApexProfile>(
-            apex_legends::get_uid_from_username_retry(String::from(&user_name), &api_key, true)
-                .await,
-            |data| format!("Your UID is {}", data.uid),
-        ), "get_uid_from_username_retry");
+        assert!(
+            print_data::<data_types::ApexProfile>(
+                apex_legends::get_uid_from_username_retry(String::from(&user_name), &api_key, true)
+                    .await,
+                |data| format!("Your UID is {}", data.uid),
+            ),
+            "get_uid_from_username_retry"
+        );
 
-        assert!(print_data::<data_types::ApexProfile>(
-            apex_legends::get_uid_from_username_retry(String::from(&user_name), &api_key, true)
-                .await,
-            |data| format!("Your UID is {}", data.uid),
-        ), "get_uid_from_username_retry");
+        assert!(
+            print_data::<data_types::ApexProfile>(
+                apex_legends::get_uid_from_username_retry(String::from(&user_name), &api_key, true)
+                    .await,
+                |data| format!("Your UID is {}", data.uid),
+            ),
+            "get_uid_from_username_retry"
+        );
     }
 
     #[tokio::test]
@@ -71,23 +83,29 @@ mod tests {
 
         let api_key = env::var("API_KEY").expect("Expected key API_KEY");
 
-        assert!(print_data::<data_types::ApexMapRotation>(
-            apex_legends::get_map_rotation_retry(&api_key, true).await,
-            |data| {
-                format!(
-                    "The current ranked map is {}",
-                    data.arenas_ranked.current.map
-                )
-            },
-        ), "get_map_rotation_retry");
-        assert!(print_data::<data_types::ApexMapRotation>(
-            apex_legends::get_map_rotation_retry(&api_key, true).await,
-            |data| {
-                format!(
-                    "The current ranked map is {}",
-                    data.arenas_ranked.current.map
-                )
-            },
-        ), "get_map_rotation_retry");
+        assert!(
+            print_data::<data_types::ApexMapRotation>(
+                apex_legends::get_map_rotation_retry(&api_key, true).await,
+                |data| {
+                    format!(
+                        "The current ranked map is {}",
+                        data.arenas_ranked.current.map
+                    )
+                },
+            ),
+            "get_map_rotation_retry"
+        );
+        assert!(
+            print_data::<data_types::ApexMapRotation>(
+                apex_legends::get_map_rotation_retry(&api_key, true).await,
+                |data| {
+                    format!(
+                        "The current ranked map is {}",
+                        data.arenas_ranked.current.map
+                    )
+                },
+            ),
+            "get_map_rotation_retry"
+        );
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,44 +1,93 @@
 #[cfg(test)]
 mod tests {
+    use apex_legends::data_types;
     use std::env;
 
+    fn print_data<T>(res: Result<T, String>, f: fn(T) -> String) {
+        match res {
+            Ok(data) => {
+                println!("{}", f(data));
+
+                assert!(true)
+            }
+            Err(e) => {
+                println!("there was an error!: {}", e);
+
+                assert!(false)
+            }
+        }
+    }
+
     #[tokio::test]
-    async fn main() {
+    async fn user() {
         dotenv::dotenv().expect("Could not load .env file");
 
         let user_name = env::var("USERNAME").expect("Expected key USERNAME");
         let api_key = env::var("API_KEY").expect("Expected key API_KEY");
 
-        match apex_legends::get_user_retry(String::from(&user_name), &api_key, true).await {
-            Ok(data) => {
-                println!(
+        print_data::<data_types::ApexUser>(
+            apex_legends::get_user_retry(String::from(&user_name), &api_key, true).await,
+            |data| {
+                format!(
                     "You are level {}, and you have {} kills.",
                     data.global.level, data.stats.br_kills.value
-                );
+                )
+            },
+        );
 
-                assert!(true)
-            }
-            Err(e) => {
-                println!("there was an error!: {}", e);
-
-                assert!(false)
-            }
-        }
-
-        match apex_legends::get_user_retry(user_name, &api_key, true).await {
-            Ok(data) => {
-                println!(
+        print_data::<data_types::ApexUser>(
+            apex_legends::get_user_retry(String::from(&user_name), &api_key, true).await,
+            |data| {
+                format!(
                     "You are level {}, and you have {} kills.",
                     data.global.level, data.stats.br_kills.value
-                );
+                )
+            },
+        );
+    }
+    #[tokio::test]
+    #[should_panic] // Because the API returns 200 OK when it should return 429
+    async fn uid() {
+        dotenv::dotenv().expect("Could not load .env file");
 
-                assert!(true)
-            }
-            Err(e) => {
-                println!("there was an error!: {}", e);
+        let user_name = env::var("USERNAME").expect("Expected key USERNAME");
+        let api_key = env::var("API_KEY").expect("Expected key API_KEY");
 
-                assert!(false)
-            }
-        }
+        print_data::<data_types::ApexProfile>(
+            apex_legends::get_uid_from_username_retry(String::from(&user_name), &api_key, true)
+                .await,
+            |data| format!("Your UID is {}", data.uid),
+        );
+        print_data::<data_types::ApexProfile>(
+            apex_legends::get_uid_from_username_retry(String::from(&user_name), &api_key, true)
+                .await,
+            |data| format!("Your UID is {}", data.uid),
+        );
+    }
+
+    #[tokio::test]
+    async fn map_rotation() {
+        dotenv::dotenv().expect("Could not load .env file");
+
+        let api_key = env::var("API_KEY").expect("Expected key API_KEY");
+
+        print_data::<data_types::ApexMapRotation>(
+            apex_legends::get_map_rotation_retry(&api_key, true).await,
+            |data| {
+                format!(
+                    "The current ranked map is {}",
+                    data.arenas_ranked.current.map
+                )
+            },
+        );
+        print_data::<data_types::ApexMapRotation>(
+            apex_legends::get_map_rotation_retry(&api_key, true).await,
+            |data| {
+                format!(
+                    "The current ranked map is {}",
+                    data.arenas_ranked.current.map
+                )
+            },
+        );
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -3,17 +3,17 @@ mod tests {
     use apex_legends::data_types;
     use std::env;
 
-    fn print_data<T>(res: Result<T, String>, f: fn(T) -> String) {
+    fn print_data<T>(res: Result<T, String>, f: fn(T) -> String) -> bool {
         match res {
             Ok(data) => {
                 println!("{}", f(data));
 
-                assert!(true)
+                true
             }
             Err(e) => {
                 println!("there was an error!: {}", e);
 
-                assert!(false)
+                false
             }
         }
     }
@@ -25,7 +25,7 @@ mod tests {
         let user_name = env::var("USERNAME").expect("Expected key USERNAME");
         let api_key = env::var("API_KEY").expect("Expected key API_KEY");
 
-        print_data::<data_types::ApexUser>(
+        assert!(print_data::<data_types::ApexUser>(
             apex_legends::get_user_retry(String::from(&user_name), &api_key, true).await,
             |data| {
                 format!(
@@ -33,9 +33,9 @@ mod tests {
                     data.global.level, data.stats.br_kills.value
                 )
             },
-        );
+        ), "get_user_retry");
 
-        print_data::<data_types::ApexUser>(
+        assert!(print_data::<data_types::ApexUser>(
             apex_legends::get_user_retry(String::from(&user_name), &api_key, true).await,
             |data| {
                 format!(
@@ -43,26 +43,26 @@ mod tests {
                     data.global.level, data.stats.br_kills.value
                 )
             },
-        );
+        ), "get_user_retry");
     }
     #[tokio::test]
-    #[should_panic] // Because the API returns 200 OK when it should return 429
     async fn uid() {
         dotenv::dotenv().expect("Could not load .env file");
 
         let user_name = env::var("USERNAME").expect("Expected key USERNAME");
         let api_key = env::var("API_KEY").expect("Expected key API_KEY");
 
-        print_data::<data_types::ApexProfile>(
+        assert!(print_data::<data_types::ApexProfile>(
             apex_legends::get_uid_from_username_retry(String::from(&user_name), &api_key, true)
                 .await,
             |data| format!("Your UID is {}", data.uid),
-        );
-        print_data::<data_types::ApexProfile>(
+        ), "get_uid_from_username_retry");
+
+        assert!(print_data::<data_types::ApexProfile>(
             apex_legends::get_uid_from_username_retry(String::from(&user_name), &api_key, true)
                 .await,
             |data| format!("Your UID is {}", data.uid),
-        );
+        ), "get_uid_from_username_retry");
     }
 
     #[tokio::test]
@@ -71,7 +71,7 @@ mod tests {
 
         let api_key = env::var("API_KEY").expect("Expected key API_KEY");
 
-        print_data::<data_types::ApexMapRotation>(
+        assert!(print_data::<data_types::ApexMapRotation>(
             apex_legends::get_map_rotation_retry(&api_key, true).await,
             |data| {
                 format!(
@@ -79,8 +79,8 @@ mod tests {
                     data.arenas_ranked.current.map
                 )
             },
-        );
-        print_data::<data_types::ApexMapRotation>(
+        ), "get_map_rotation_retry");
+        assert!(print_data::<data_types::ApexMapRotation>(
             apex_legends::get_map_rotation_retry(&api_key, true).await,
             |data| {
                 format!(
@@ -88,6 +88,6 @@ mod tests {
                     data.arenas_ranked.current.map
                 )
             },
-        );
+        ), "get_map_rotation_retry");
     }
 }


### PR DESCRIPTION
# Intro

This is a pretty big Pull Request with lots of new things and improvements, so I will try to break it down:

## Documentation

I added some amount of documentation to the lib.rs functions, which are the ones the end user will use. They include some examples and notes if applicable

## New ways of handling errors and a better way of retrying requests

Previously, the requests only returned an error or the result. Now, they return either the result or a tuple with the error and the response headers. That is because the headers contain useful information, for example they tell you your current request limit.

- **If there was an error (not code `200`)**:
   - If the error was a 429, they read the headers to know how much time has to pass before retrying. If there's an error when reading the headers, it will just use the default timeout (a constant). Then, they sleep that amount of time and retry once more.
   - If the error was other than 429, a function is called that returns an appropriate custom error message depending on the code. This function is used to standardize error messages across all functions, and to avoid repeating code.

- **If there was not an error (code `200 OK`)**:
   - If the request returned a valid value, it just returns that (nothing new)
   - If the request returned an error message, previously serde errored out when trying to parse it. Now, that error will be catched, and the message will be parsed to an `ApexError` (which is just a message) and returned to the user.

## Added more tests

I separated the tests into three, testing the three functions in `lib.rs`. 

# Known problems

The API has a bug where the endpoint `getuseruid` returns `200 OK` when it should return `429`. I asked Hugo to take a look at it, so a fix might be on the way. [Source](https://discord.com/channels/556094211972136970/829068298061742110/1007327671023308901)

# Future ideas

The error codes could be passed down to the user to let it handle them.
